### PR TITLE
Visual bugs

### DIFF
--- a/app/src/main/res/layout/activity_account.xml
+++ b/app/src/main/res/layout/activity_account.xml
@@ -12,9 +12,8 @@
         xmlns:app="http://schemas.android.com/apk/res-auto"
         >
 
-
         <com.google.android.material.appbar.AppBarLayout
-            android:layout_width="wrap_content"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:theme="@style/ThemeOverlay.AppCompat.ActionBar"
             app:popupTheme="@style/ThemeOverlay.AppCompat.Light"
@@ -22,16 +21,13 @@
             android:id="@+id/toolbarTransactionsPage"
             >
 
-
-
             <ImageView
-                android:layout_width="433dp"
+                android:layout_width="wrap_content"
+                android:layout_gravity="center"
                 android:padding="10dp"
                 android:layout_height="100dp"
                 android:src="@drawable/logo"
                 android:contentDescription="@string/logo" />
-
-
 
         </com.google.android.material.appbar.AppBarLayout>
 
@@ -56,67 +52,76 @@
             android:text="@string/account_name" />
 
         <TextView
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_below="@+id/toolbarTransactionsPage"
-            android:paddingStart="10dp"
-            android:layout_marginTop="100dp"
-            android:textSize="20sp"
-            android:typeface="serif"
-            android:text="@string/transaction_history" />
-
-        <TextView
             android:id="@+id/balance"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_below="@+id/toolbarTransactionsPage"
-            android:layout_marginTop="100dp"
-            android:layout_marginStart="220dp"
+            android:layout_below="@id/NameOfAccount"
+            android:layout_marginTop="10dp"
             android:textSize="20sp"
             android:typeface="serif"
             android:text="@string/balance" />
 
         <View
-            android:layout_marginTop="140dp"
-            android:layout_below="@+id/toolbarTransactionsPage"
+            android:id="@+id/horizontalDivider"
+            android:layout_below="@id/balance"
             android:layout_width="match_parent"
             android:layout_height="2dp"
-            android:background="@color/BankGreen"/>
+            android:layout_marginTop="10dp"
+            android:background="@color/BankGreen"
+            />
+
+        <TextView
+            android:id="@+id/historyHeader"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_below="@id/horizontalDivider"
+            android:layout_marginTop="10dp"
+            android:layout_centerInParent="true"
+            android:textSize="20sp"
+            android:typeface="serif"
+            android:text="@string/transaction_history" />
 
         <androidx.recyclerview.widget.RecyclerView
+            android:layout_below="@id/historyHeader"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_marginTop="250dp"
             android:padding="10dp"
             android:id="@+id/TransactionRecycler"/>
 
-        <Button
-
-            android:text="withdraw"
-            android:id="@+id/Btn_Withdraw"
-
-            android:layout_width="170dp"
-            android:layout_height="@dimen/createAcct_height"
-            android:layout_below="@+id/TransactionRecycler"
-            android:layout_marginLeft="220dp"
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_below="@id/TransactionRecycler"
             android:layout_marginTop="20dp"
-            android:contentDescription="@string/new_account"
-            android:padding="0dp"
-            android:background="@drawable/button_blank"
-            />
+            android:layout_marginStart="20dp"
+            android:layout_marginEnd="20dp">
 
-        <Button
-            android:text="deposit"
-            android:id="@+id/Btn_Deposit"
-            android:layout_width="170dp"
-            android:layout_height="@dimen/createAcct_height"
-            android:layout_below="@+id/TransactionRecycler"
-            android:layout_marginLeft="20dp"
-            android:layout_marginTop="20dp"
-            android:contentDescription="@string/new_account"
-            android:padding="0dp"
-            android:background="@drawable/button_blank"
-            />
+            <Button
+                android:text="@string/deposit"
+                android:id="@+id/Btn_Deposit"
+                android:layout_width="170dp"
+                android:layout_height="@dimen/createAcct_height"
+                android:layout_weight="0.5"
+                android:contentDescription="@string/new_account"
+                android:padding="0dp"
+                android:layout_marginEnd="10dp"
+                android:background="@drawable/button_blank"
+                />
+
+            <Button
+                android:text="@string/withdraw"
+                android:id="@+id/Btn_Withdraw"
+                android:layout_width="170dp"
+                android:layout_height="@dimen/createAcct_height"
+                android:layout_weight="0.5"
+                android:contentDescription="@string/new_account"
+                android:padding="0dp"
+                android:layout_marginStart="10dp"
+                android:background="@drawable/button_blank"
+                />
+
+        </LinearLayout>
+
 
 
     </RelativeLayout>

--- a/app/src/main/res/layout/activity_account.xml
+++ b/app/src/main/res/layout/activity_account.xml
@@ -57,6 +57,8 @@
             android:layout_height="wrap_content"
             android:layout_below="@id/NameOfAccount"
             android:layout_marginTop="10dp"
+            android:layout_marginStart="20dp"
+            android:layout_marginEnd="20dp"
             android:textSize="20sp"
             android:typeface="serif"
             android:text="@string/balance" />

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -13,7 +13,7 @@
     >
 
     <com.google.android.material.appbar.AppBarLayout
-        android:layout_width="wrap_content"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:theme="@style/ThemeOverlay.AppCompat.ActionBar"
         app:popupTheme="@style/ThemeOverlay.AppCompat.Light"
@@ -23,9 +23,10 @@
 
         <ImageView
             android:id="@+id/MainLogo"
-            android:layout_width="433dp"
-            android:padding="10dp"
+            android:layout_width="wrap_content"
             android:layout_height="100dp"
+            android:layout_gravity="center"
+            android:padding="10dp"
             android:src="@drawable/logo"
             android:contentDescription="@string/logo" />
 

--- a/app/src/main/res/layout/activity_transaction.xml
+++ b/app/src/main/res/layout/activity_transaction.xml
@@ -45,48 +45,44 @@
             android:typeface="serif"
             android:text="@string/datetime" />
 
-        <LinearLayout
-            android:id="@+id/amountBalanceBlock"
-            android:layout_width="match_parent"
+        <TextView
+            android:id="@+id/transactionActivityBal"
+            android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_below="@id/transactionActivityName"
-            android:layout_marginTop="20dp"
+            android:layout_marginTop="10dp"
             android:layout_marginStart="20dp"
-            android:layout_marginEnd="20dp">
+            android:layout_marginEnd="20dp"
+            android:textSize="20sp"
+            android:typeface="serif"
+            android:text="@string/current_bal" />
 
-            <TextView
-                android:id="@+id/transactionActivityAmt"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_weight="0.5"
-                android:textSize="20sp"
-                android:typeface="serif"
-                android:text="@string/amount" />
-
-            <TextView
-                android:id="@+id/transactionActivityBal"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_weight="0.5"
-                android:textSize="20sp"
-                android:typeface="serif"
-                android:text="@string/current_bal" />
-
-        </LinearLayout>
 
         <View
             android:id="@+id/transactionDivider"
-            android:layout_below="@id/amountBalanceBlock"
+            android:layout_below="@id/transactionActivityBal"
             android:layout_width="match_parent"
             android:layout_height="2dp"
             android:layout_marginTop="10dp"
             android:background="@color/BankGreen"/>
 
         <TextView
+            android:id="@+id/transactionActivityAmt"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_below="@id/transactionDivider"
+            android:layout_marginTop="10dp"
+            android:layout_marginStart="20dp"
+            android:layout_marginEnd="20dp"
+            android:textSize="20sp"
+            android:typeface="serif"
+            android:text="@string/amount" />
+
+        <TextView
             android:id="@+id/transactionActivityMessage"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_below="@+id/transactionDivider"
+            android:layout_below="@+id/transactionActivityAmt"
             android:layout_marginTop="10dp"
             android:padding="20dp"
             android:textSize="20sp"

--- a/app/src/main/res/layout/activity_transaction.xml
+++ b/app/src/main/res/layout/activity_transaction.xml
@@ -15,7 +15,7 @@
 
 
         <com.google.android.material.appbar.AppBarLayout
-            android:layout_width="wrap_content"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:theme="@style/ThemeOverlay.AppCompat.ActionBar"
             app:popupTheme="@style/ThemeOverlay.AppCompat.Light"
@@ -23,19 +23,15 @@
             android:id="@+id/toolbarTransactionsPage"
             >
 
-
-
             <ImageView
-                android:layout_width="433dp"
+                android:layout_width="wrap_content"
+                android:layout_gravity="center"
                 android:padding="10dp"
                 android:layout_height="100dp"
                 android:src="@drawable/logo"
                 android:contentDescription="@string/logo" />
 
-
-
         </com.google.android.material.appbar.AppBarLayout>
-
 
 
         <TextView
@@ -49,66 +45,53 @@
             android:typeface="serif"
             android:text="@string/datetime" />
 
-        <TextView
-            android:id="@+id/transactionActivityAmt"
-            android:layout_width="wrap_content"
+        <LinearLayout
+            android:id="@+id/amountBalanceBlock"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_below="@+id/toolbarTransactionsPage"
-            android:paddingStart="20dp"
-            android:layout_marginTop="100dp"
-            android:textSize="20sp"
-            android:typeface="serif"
-            android:text="@string/amount" />
+            android:layout_below="@id/transactionActivityName"
+            android:layout_marginTop="20dp"
+            android:layout_marginStart="20dp"
+            android:layout_marginEnd="20dp">
 
-        <TextView
-            android:id="@+id/transactionActivityBal"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_below="@+id/toolbarTransactionsPage"
-            android:paddingStart="10dp"
-            android:layout_marginTop="100dp"
-            android:textSize="20sp"
-            android:typeface="serif"
-            android:layout_marginStart="220dp"
-            android:text="@string/current_bal" />
+            <TextView
+                android:id="@+id/transactionActivityAmt"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_weight="0.5"
+                android:textSize="20sp"
+                android:typeface="serif"
+                android:text="@string/amount" />
+
+            <TextView
+                android:id="@+id/transactionActivityBal"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_weight="0.5"
+                android:textSize="20sp"
+                android:typeface="serif"
+                android:text="@string/current_bal" />
+
+        </LinearLayout>
 
         <View
-            android:layout_marginTop="140dp"
-            android:layout_below="@+id/toolbarTransactionsPage"
+            android:id="@+id/transactionDivider"
+            android:layout_below="@id/amountBalanceBlock"
             android:layout_width="match_parent"
             android:layout_height="2dp"
+            android:layout_marginTop="10dp"
             android:background="@color/BankGreen"/>
 
         <TextView
             android:id="@+id/transactionActivityMessage"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_below="@+id/toolbarTransactionsPage"
+            android:layout_below="@+id/transactionDivider"
+            android:layout_marginTop="10dp"
             android:padding="20dp"
-            android:layout_marginTop="140dp"
             android:textSize="20sp"
             android:typeface="serif"
-            android:text="Message" />
-
-
-        <Button
-            android:text="go back"
-            android:layout_width="170dp"
-            android:layout_height="@dimen/createAcct_height"
-            android:layout_below="@+id/transactionActivityMessage"
-            android:layout_marginLeft="130dp"
-            android:layout_marginTop="20dp"
-            android:contentDescription="@string/new_account"
-            android:padding="0dp"
-            android:background="@drawable/button_blank"
-            android:onClick="toAccountActivity"
-            />
-
-
-
-
-
-
+            android:text="@string/default_memo" />
 
     </RelativeLayout>
 </ScrollView>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -16,7 +16,7 @@
     <string name="mary_sampson">Mary Sampson</string>
     <string name="logo">Logo</string>
     <string name="account_name">account_name</string>
-    <string name="transaction_history">Transaction History</string>
+    <string name="transaction_history">History</string>
     <string name="account_activity">AccountActivity</string>
 
 
@@ -33,6 +33,7 @@
     <string name="balance">Balance</string>
     <string name="withdraw">Withdraw</string>
     <string name="deposit">Deposit</string>
+    <string name="default_memo">DEFAULT MEMO</string>
     <string name="withdraw_test">WITHDRAW</string>
     <string name="deposit_test">DEPOSIT</string>
     <string name="current_bal">Current Bal</string>


### PR DESCRIPTION
Resolves https://github.com/jleeboyd/family-bank-app/issues/35

As well as minor visual improvements across all three screens.

Logo on all screens is now properly centered
![image](https://user-images.githubusercontent.com/57050171/99191018-d8848e00-271e-11eb-82bb-7d67e4ffc29f.png)

In an attempt to clear up the wonky auto-formatting that happens for sufficiently large numbers in the "account balance" readouts these have been split
![image](https://user-images.githubusercontent.com/57050171/99191072-21d4dd80-271f-11eb-903a-a31a98d464a8.png)

EDIT: almost forgot to mention, also incorporates changes made in https://github.com/jleeboyd/family-bank-app/pull/36 so I don't need to wait for github and CI to do things

At time of writing it occurred to me I should do this to the transaction details screen, too, so I'm going to do that and then push again real quick, see comments below.