### PR TITLE
removed balance line from transaction details

### DIFF
--- a/app/src/androidTest/java/com/example/family_bank_app/MainActivityTest.java
+++ b/app/src/androidTest/java/com/example/family_bank_app/MainActivityTest.java
@@ -194,7 +194,6 @@ public class MainActivityTest {
     public void checkTransaction(String transactionDate, String transactionBalance, String transactionAmount, String transactionNote, String transactionStatus) throws InterruptedException {
 
 //        onView(withId(R.id.transactionActivityDate)).check(matches(withText(transactionDate)));
-        onView(withId(R.id.transactionActivityBal)).check(matches(withText("Balance: $" + transactionBalance + ".0"))); // TODO: fix single digit display balance
         onView(withId(R.id.transactionActivityAmt)).check(matches(withText("Amount: $" + transactionAmount + ".0"))); // Amount?
         onView(withId(R.id.transactionActivityMessage)).check(matches(withText("Note: " + transactionNote)));
         onView(withId(R.id.transactionActivityStatus)).check(matches(withText("Status: " + transactionStatus)));

--- a/app/src/main/java/com/example/family_bank_app/TransactionActivity.java
+++ b/app/src/main/java/com/example/family_bank_app/TransactionActivity.java
@@ -39,7 +39,6 @@ public class TransactionActivity extends AppCompatActivity implements Dialog_Del
 
         note = getIntent().getStringExtra("NAME");
         amount = getIntent().getDoubleExtra("AMOUNT", 0);
-        currentBal = getIntent().getDoubleExtra("BAL", 0);
         date = getIntent().getStringExtra("DATE");
         viewModel = new AccountViewModel();
         transactionUID = getIntent().getLongExtra("TRANSACTIONUID", 0);
@@ -73,13 +72,11 @@ public class TransactionActivity extends AppCompatActivity implements Dialog_Del
 
         Note = findViewById(R.id.transactionActivityMessage);
         Amount = findViewById(R.id.transactionActivityAmt);
-        CurrentBal = findViewById(R.id.transactionActivityBal);
         Date = findViewById(R.id.transactionActivityDate);
         Status = findViewById(R.id.transactionActivityStatus);
 
         Note.setText("Note: " + note);
         Amount.setText("Amount: $" + amount);
-        CurrentBal.setText("Balance: $" + currentBal);
         Date.setText(date);
 
         if (status.equals("ok")) {

--- a/app/src/main/res/layout/activity_transaction.xml
+++ b/app/src/main/res/layout/activity_transaction.xml
@@ -53,22 +53,9 @@
             android:layout_below="@+id/toolbarTransactionsPage"
             android:layout_marginStart="5dp" />
 
-        <TextView
-            android:id="@+id/transactionActivityBal"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_below="@id/transactionActivityDate"
-            android:layout_marginTop="10dp"
-            android:layout_marginStart="20dp"
-            android:layout_marginEnd="20dp"
-            android:textSize="20sp"
-            android:typeface="serif"
-            android:text="@string/current_bal" />
-
-
         <View
             android:id="@+id/transactionDivider"
-            android:layout_below="@id/transactionActivityBal"
+            android:layout_below="@id/transactionActivityDate"
             android:layout_width="match_parent"
             android:layout_height="2dp"
             android:layout_marginTop="10dp"


### PR DESCRIPTION
Wasn't functioning as intended, and without more tuning to the individual transaction details screen even intended functionality would have ended up confusing. Removed altogether

![image](https://user-images.githubusercontent.com/57050171/100741100-8c785100-338e-11eb-9f98-c8de70d1afec.png)
